### PR TITLE
Correctly identify local variable rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -304,7 +304,6 @@ dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    =
 # Local variables must be camelCase
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
 dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = field
 dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
 dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
 dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent


### PR DESCRIPTION
I noticed that local variable violations didn't seem to be picked up. Given that we're talking about locals and not fields, that additional criterium seems to be the cause. Removing the line fixes it for me.

I've tested this on Visual Studio 16.0.3.