### PR TITLE
Fix csharp_space_between_parentheses with valid value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.0.2 (Using https://semver.org/)
-# Updated: 2019-05-22
+# Version: 1.0.3 (Using https://semver.org/)
+# Updated: 2019-06-28
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
 
@@ -169,7 +169,7 @@ csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_parentheses = expressions
+csharp_space_between_parentheses = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after


### PR DESCRIPTION
I was seeing a bug where parentheses in expressions were getting spaces added to them. Finally took a look. It turns out the docs were missing/incorrect when I added this setting.

`((h1 << 5) + h1) ^ h2` would be formatted as `( ( h1 << 5 ) + h1 ) ^ h2`.

See https://github.com/MicrosoftDocs/visualstudio-docs/issues/1461 for more info.