### PR TITLE
.cmd and .bat files should use CRLF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Version: 1.3.1 (Using https://semver.org/)
+# Version: 1.3.2 (Using https://semver.org/)
 # Updated: 2019-08-04
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
@@ -53,6 +53,7 @@ indent_size = 2
 
 # Batch Files
 [*.{cmd,bat}]
+end_of_line = crlf
 
 # Bash Files
 [*.sh]

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,12 @@
 # Set default behavior to automatically normalize line endings.
 * text=auto
 
-# Force bash scripts to always use lf line endings so that if a repo is accessed
+# Force batch scripts to always use CRLF line endings so that if a repo is accessed
+# in Windows via a file share from Linux, the scripts will work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf
 


### PR DESCRIPTION
I was reading the VS Code Docs and found some [guidance about line endings](https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files) in a `.gitattributes` file. I then realized that given we have taken out the default CRLF line ending, we need to be explicit about `.cmd` and `.bat` files.