### PR TITLE
Prefer Simple using Statements as Suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.3.2 (Using https://semver.org/)
-# Updated: 2019-08-04
+# Version: 1.4.0 (Using https://semver.org/)
+# Updated: 2020-01-28
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -161,7 +161,7 @@ csharp_style_deconstructed_variable_declaration = true:warning
 csharp_style_pattern_local_over_anonymous_function = true:warning
 csharp_using_directive_placement = inside_namespace:warning
 csharp_prefer_static_local_function = true:warning
-csharp_prefer_simple_using_statement = false:warning
+csharp_prefer_simple_using_statement = true:suggestion
 
 ##########################################
 # .NET Formatting Conventions


### PR DESCRIPTION
I've come to find these useful in unit tests. I think I went a bit too extreme with turning this feature off completely and at the very least we should raise info/suggestion level messages. 

```c#
// csharp_prefer_simple_using_statement = true
using var a = b;

// csharp_prefer_simple_using_statement = false
using (var a = b)
{
}
```