### PR TITLE
Prefer Simplified Interpolation & .jsm/.vbx Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.4.1 (Using https://semver.org/)
-# Updated: 2020-02-01
+# Version: 1.5.0 (Using https://semver.org/)
+# Updated: 2020-02-10
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.

--- a/.editorconfig
+++ b/.editorconfig
@@ -28,10 +28,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 
 # Visual Studio XML Project Files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
 indent_size = 2
 
-# Various XML Configuration Files
+# XML Configuration Files
 [*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
 indent_size = 2
 
@@ -48,7 +48,7 @@ indent_size = 2
 trim_trailing_whitespace = false
 
 # Web Files
-[*.{htm,html,js,ts,tsx,css,sass,scss,less,svg,vue}]
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
 indent_size = 2
 
 # Batch Files
@@ -70,7 +70,7 @@ indent_style = tab
 
 # .NET Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
-[*.{cs,csx,cake,vb}]
+[*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
 dotnet_style_qualification_for_field = true:warning
@@ -115,6 +115,8 @@ dotnet_code_quality_unused_parameters = all:warning
 # More style options (Undocumented)
 # https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
 dotnet_style_operator_placement_when_wrapping = end_of_line
+# https://github.com/dotnet/roslyn/pull/40070
+dotnet_style_prefer_simplified_interpolation = true:warning
 
 # C# Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
@@ -226,7 +228,7 @@ csharp_preserve_single_line_blocks = true
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-naming-conventions
 ##########################################
 
-[*.{cs,csx,cake,vb}]
+[*.{cs,csx,cake,vb,vbx}]
 
 ##########################################
 # Styles

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
-![.editorconfig Banner](https://media.githubusercontent.com/media/RehanSaeed/EditorConfig/master/Images/Banner.png)
+![.editorconfig Banner](Images/Banner.png)
 
 A very generic [.editorconfig](https://github.com/RehanSaeed/EditorConfig/blob/master/.editorconfig) file supporting the following file types:
 
 - C# - .cs, .csx, .cake
-- Visual Basic - .vb
+- Visual Basic - .vb, vbx
 - Script - .sh, .ps1, .psm1, .bat, .cmd
 - XML - .xml, .config, .props, .targets, .nuspec, .resx, .ruleset
 - JSON - .json, .json5
 - YAML - .yml,  .yaml
 - HTML - .htm, .html
-- JavaScript - .js, .ts, .tsx, .vue
+- JavaScript - .js, .jsm, .ts, .tsx, .vue
 - CSS - .css, .sass, .scss, .less
 - SVG - .svg
 - Markdown - .md
 - Visual Studio - .sln, .csproj, .vbproj, .vcxproj, .vcxproj.filters, .proj, .projitems, .shproj
 - Makefile
 
-### For .NET code
+### .NET Code Style
+
 Extensive code style settings for C# and VB.NET have been defined that require the latest C# features to be used.
 All C# related code styles are consistent with [StyleCop's](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) default styles.
 All .NET naming conventions are consistent with the .NET Framework Design Guideline's [Naming Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines).


### PR DESCRIPTION
- Add `dotnet_style_prefer_simplified_interpolation = true:warning` (https://github.com/dotnet/roslyn/pull/40070).
- Add JavaScript modules `.jsm` file extension.
- Add `.vbx` file extension to match `.csx`.
- Remove duplicate `.vcxproj` file extension.

Mixed bag PR. I'll split this up if needed.