### PR TITLE
Add samples to verify intended behaviors

### DIFF
--- a/Samples/CSharp/CSharpSamples.csproj
+++ b/Samples/CSharp/CSharpSamples.csproj
@@ -1,0 +1,64 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{29BDC663-4524-4258-8621-980288CC6E9F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <NoStandardLibraries>false</NoStandardLibraries>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>7.2</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodeAnalysisRuleSet>CSharpSamples.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>CSharpSamples.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>EditorConfigCSharpSamples</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CSharpSamples.ruleset" />
+    <None Include="packages.config" />
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FieldExamples.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
+  <ProjectExtensions>
+    <VisualStudio AllowExistingFolder="true" />
+  </ProjectExtensions>
+</Project>

--- a/Samples/CSharp/CSharpSamples.ruleset
+++ b/Samples/CSharp/CSharpSamples.ruleset
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for EditorConfig" Description="Code analysis rules for EditorConfig.csproj." ToolsVersion="15.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1025" Action="None" />
+    <Rule Id="SA1124" Action="None" />
+    <Rule Id="SA1131" Action="None" />
+    <Rule Id="SA1203" Action="None" />
+    <Rule Id="SA1402" Action="None" />
+    <Rule Id="SA1403" Action="None" />
+    <Rule Id="SA1507" Action="None" />
+    <Rule Id="SA1639" Action="Warning" />
+    <Rule Id="SA1649" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Samples/CSharp/CSharpSamples.sln
+++ b/Samples/CSharp/CSharpSamples.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.539
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpSamples", "CSharpSamples.csproj", "{29BDC663-4524-4258-8621-980288CC6E9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29BDC663-4524-4258-8621-980288CC6E9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29BDC663-4524-4258-8621-980288CC6E9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29BDC663-4524-4258-8621-980288CC6E9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29BDC663-4524-4258-8621-980288CC6E9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0F1033D5-0C95-44D7-ADB8-8D536F772355}
+	EndGlobalSection
+EndGlobal

--- a/Samples/CSharp/FieldsExamples.cs
+++ b/Samples/CSharp/FieldsExamples.cs
@@ -1,0 +1,241 @@
+// Copyright (c) 2019 Henry Gabryjelski
+namespace My
+{
+    internal class FieldsExamples
+    {
+        // StyleCop requires members in the following order: Public, Internal, Protected Internal, Protected, Private
+        // See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+        #region // `Public` fields
+        /*
+         * StyleCop explicitly prohibits any non-private fields, resulting in essentially four rules:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md AccessibleFieldsMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md AccessibleFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         * (4) all other fields are explicitly prohibited
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md FieldsMustBePrivate
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * also explicitly prohibit publicly-exposed fields (thus applies to accesibility modifier `public`),
+         * with only two exceptions to the prohibition:
+         * (1) const fields
+         * (2) static readonly fields
+         * And requires those fields to be PascalCase.
+         * See https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+         * Therefore, the .NET Guidelines for `public` fields are compatible with StyleCop.
+         */
+
+        // Allowed by both .NET Guidelines and StyleCop, and are properly PascalCased
+        public        const    int PascalCasePublicConstField          = 1;
+        public static readonly int PascalCasePublicStaticReadonlyField = 1;
+
+        // Allowed by both .NET Guidelines and StyleCop, but should generate a warning due to use of camelCase
+        public        const    int camelCasePublicConstField           = 1;
+        public static readonly int camelCasePublicStaticReadonlyField  = 1;
+
+        // Prohibited by both .NET Guidelines and StyleCop (other publicly-exposed fields)
+        public static          int PascalCasePublicStaticField         = 1;
+        public static          int camelCasePublicStaticField          = 1;
+        public        readonly int PascalCasePublicReadonlyField       = 1;
+        public        readonly int camelCasePublicReadonlyField        = 1;
+        public                 int PascalCasePublicField               = 1;
+        public                 int camelCasePublicField                = 1;
+        #endregion // `Public` fields
+        #region // `Internal` fields
+        /*
+         * StyleCop explicitly prohibits any non-private fields, resulting in essentially four rules:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         * (4) all other fields are explicitly prohibited
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md FieldsMustBePrivate
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * only apply to publicly-exposed fields.  Therefore, because fields with an accesibility modifier of `internal`
+         * are only accessible within the containing assembly, they are outside the scope of the .NET guidelines.
+         */
+
+        // Allowed by both .NET Guidelines and StyleCop, and are properly PascalCased
+        internal        const    int PascalCaseInternalConstField          = 1;
+        internal static readonly int PascalCaseInternalStaticReadonlyField = 1;
+
+        // Allowed by both .NET Guidelines and StyleCop, but should generate a warning due to use of camelCase
+        internal        const    int camelCaseInternalConstField           = 1;
+        internal static readonly int camelCaseInternalStaticReadonlyField  = 1;
+
+        // Prohibited by both .NET Guidelines and StyleCop (other publicly-exposed fields)
+        internal static          int PascalCaseInternalStaticField   = 1;
+        internal static          int camelCaseInternalStaticField    = 1;
+        internal        readonly int PascalCaseInternalReadonlyField = 1;
+        internal        readonly int camelCaseInternalReadonlyField  = 1;
+        internal                 int PascalCaseInternalField         = 1;
+        internal                 int camelCaseInternalField          = 1;
+        #endregion // `Internal` fields
+        #region // `Protected Internal` fields
+        /*
+         * StyleCop explicitly prohibits any non-private fields, resulting in essentially four rules:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md AccessibleFieldsMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md AccessibleFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         * (4) all other fields are explicitly prohibited
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md FieldsMustBePrivate
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * also explicitly prohibit publicly-exposed fields (thus applies to accesibility modifier `protected internal`),
+         * with only two exceptions to the prohibition:
+         * (1) const fields
+         * (2) static readonly fields
+         * And requires those fields to be PascalCase.
+         * See https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+         * Therefore, the .NET Guidelines for `public` fields are compatible with StyleCop.
+         */
+
+        // Allowed by both .NET Guidelines and StyleCop, and are properly PascalCased
+        protected internal        const    int PascalCaseProtectedInternalConstField          = 1;
+        protected internal static readonly int PascalCaseProtectedInternalStaticReadonlyField = 1;
+
+        // Allowed by both .NET Guidelines and StyleCop, but should generate a warning due to use of camelCase
+        protected internal        const    int camelCaseProtectedInternalConstField           = 1;
+        protected internal static readonly int camelCaseProtectedInternalStaticReadonlyField  = 1;
+
+        // Prohibited by both .NET Guidelines and StyleCop (other publicly-exposed fields)
+        protected internal static          int PascalCaseProtectedInternalStaticStaticField   = 1;
+        protected internal static          int camelCaseProtectedInternalStaticField          = 1;
+        protected internal        readonly int PascalCaseProtectedInternalReadonlyField       = 1;
+        protected internal        readonly int camelCaseProtectedInternalReadonlyField        = 1;
+        protected internal                 int PascalCaseProtectedInternalField               = 1;
+        protected internal                 int camelCaseProtectedInternalField                = 1;
+        #endregion // `Protected Internal` fields
+        #region // `Protected` fields
+        /*
+         * StyleCop explicitly prohibits any non-private fields, resulting in essentially four rules:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         * (4) all other fields are explicitly prohibited
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md FieldsMustBePrivate
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * also explicitly prohibit publicly-exposed fields (thus applies to accesibility modifier `protected`),
+         * with only two exceptions to the prohibition:
+         * (1) const fields
+         * (2) static readonly fields
+         * And requires those fields to be PascalCase.
+         * See https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+         * Therefore, the .NET Guidelines for `public` fields are compatible with StyleCop.
+         */
+
+        // Allowed by both .NET Guidelines and StyleCop, and are properly PascalCased
+        protected        const    int PascalCaseProtectedConstField          = 1;
+        protected static readonly int PascalCaseProtectedStaticReadonlyField = 1;
+
+        // Allowed by both .NET Guidelines and StyleCop, but should generate a warning due to use of camelCase
+        protected        const    int camelCaseProtectedConstField           = 1;
+        protected static readonly int camelCaseProtectedStaticReadonlyField  = 1;
+
+        // Prohibited by both .NET Guidelines and StyleCop (other publicly-exposed fields)
+        protected static          int PascalCaseProtectedStaticField         = 1;
+        protected static          int camelCaseProtectedStaticField          = 1;
+        protected        readonly int PascalCaseProtectedReadonlyField       = 1;
+        protected        readonly int camelCaseProtectedReadonlyField        = 1;
+        protected                 int PascalCaseProtectedField               = 1;
+        protected                 int camelCaseProtectedField                = 1;
+        #endregion // `Protected` fields
+        #region // `Private Protected` fields
+        /*
+         * StyleCop explicitly prohibits any non-private fields, resulting in essentially four rules:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         * (4) all other fields are explicitly prohibited
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md FieldsMustBePrivate
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * only apply to publicly-exposed fields.  Therefore, because fields with an accesibility modifier of `private protected`
+         * are only accessible within the containing assembly, they are outside the scope of the .NET guidelines.
+         */
+
+        // Allowed by StyleCop, and are properly PascalCased (.NET guidelines silent on fields that are not publicly exposed)
+        private protected        const    int PascalCasePrivateProtectedConstField          = 1;
+        private protected static readonly int PascalCasePrivateProtectedStaticReadonlyField = 1;
+
+        // Allowed by StyleCop, and are properly camelCased (.NET guidelines silent on fields that are not publicly exposed)
+        private protected        const    int camelCasePrivateProtectedConstField           = 1;
+        private protected static readonly int camelCasePrivateProtectedStaticReadonlyField  = 1;
+
+        // Prohibited StyleCop (other publicly-exposed fields)
+        private protected static          int PascalCasePrivateProtectedStaticField         = 1;
+        private protected static          int camelCasePrivateProtectedStaticField          = 1;
+        private protected        readonly int PascalCasePrivateProtectedReadonlyField       = 1;
+        private protected        readonly int camelCasePrivateProtectedReadonlyField        = 1;
+        private protected                 int PascalCasePrivateProtectedField               = 1;
+        private protected                 int camelCasePrivateProtectedField                = 1;
+        #endregion // `Private Protected` fields
+        #region // `Private` fields
+        /*
+         * StyleCop allows private fields.  The rules for `const` and `static readonly` still take precedence:
+         * (1) const fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md ConstFieldNamesMustBeginWithUpperCaseLetter
+         * (2) static readonly fields must be PascalCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md StaticReadonlyFieldsMustBeginWithUpperCaseLetter
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter
+         * (3) other private fields must be camelCase
+         *     See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md FieldNamesMustBeginWithLowerCaseLetter
+         *
+         * The .NET Framework [Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index)
+         * only apply to publicly-exposed fields.  Therefore, because fields with an accesibility modifier of `private`
+         * are only accessible within the containing class, they are outside the scope of the .NET guidelines.
+         */
+
+        // Allowed by StyleCop, and are properly PascalCased (.NET guidelines silent on fields that are not publicly exposed)
+        private        const    int PascalCasePrivateConstField          = 1;
+        private static readonly int PascalCasePrivateStaticReadonlyField = 1;
+
+        // Allowed by StyleCop, and are properly camelCased (.NET guidelines silent on fields that are not publicly exposed)
+        private static          int camelCasePrivateStaticField          = 1;
+        private        readonly int camelCasePrivateReadonlyField        = 1;
+        private                 int camelCasePrivateField                = 1;
+
+        // Allowed by StyleCop, but should generate a warning due to use of camelCase
+        private        const    int camelCasePrivateConstField           = 1;
+        private static readonly int camelCasePrivateStaticReadonlyField  = 1;
+
+        // Allowed by StyleCop, but should generate a warning due to use of PascalCase
+        private static          int PascalCasePrivateStaticField         = 1;
+        private        readonly int PascalCasePrivateReadonlyField       = 1;
+        private                 int PascalCasePrivateField               = 1;
+        #endregion // `Private` fields
+
+        private void Foo() // To get around warnings telling you fields must be readonly.
+        {
+            // prevent IDE0044 "Make field readonly"
+            camelCasePrivateStaticField = 1;
+            this.camelCasePrivateField = 1;
+            PascalCasePrivateStaticField = 1;
+            this.PascalCasePrivateField = 1;
+        }
+    }
+}

--- a/Samples/CSharp/packages.config
+++ b/Samples/CSharp/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
+</packages>

--- a/Samples/CSharp/stylecop.json
+++ b/Samples/CSharp/stylecop.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "copyrightText": "Copyright (c) 2019 Henry Gabryjelski",
+      "xmlHeader": false
+    }
+  }
+}


### PR DESCRIPTION
This is the sample code I had that helped to confirm the **_intended_** behavior of the .editorconfig settings for C#.

While not complete, this corresponds to the file I shared in the past when we worked on the many naming rules at the end of the `.editorconfig` file.

This PR just adds the buildable source.  This is useful for manual regression testing, as well as providing examples to users of the result of the various naming rules.

