### PR TITLE
Charset for .resx files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.6.0 (Using https://semver.org/)
-# Updated: 2020-07-28
+# Version: 1.6.1 (Using https://semver.org/)
+# Updated: 2020-09-08
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.

--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,10 @@ end_of_line = lf
 [Makefile]
 indent_style = tab
 
+# XML Resource Files
+[*.resx]
+charset = utf-8bom
+
 ##########################################
 # File Header (Uncomment to support file headers)
 # https://docs.microsoft.com/en-us/visualstudio/ide/reference/add-file-header


### PR DESCRIPTION
XML Resource (`.resx`) Files must encoded in UTF-8 with the Byte Order Mark (BOM) present to be correctly interpreted by Visual Studio 2019. This likely also applies to older versions of Visual Studio although I have not tested these. In addition, this encoding is necessary for some of the resource APIs within the .NET Framework to function correctly.

This PR adds an explicit charset of `utf-8bom` for `.resx` files, to ensure correct formatting.

It also makes an update to the last updated date and increments the patch version.