### PR TITLE
Updating SA1636 header rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,11 +65,11 @@ indent_style = tab
 
 ##########################################
 # File Header (Uncomment to support file headers)
-# https://docs.microsoft.com/en-us/visualstudio/ide/reference/add-file-header
+# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
 ##########################################
 
 # [*.{cs,csx,cake,vb,vbx}]
-# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\nCopyright (©) PROJECT-AUTHOR. All Rights Reserved\n</copyright>
+# file_header_template = <copyright file="{fileName}" company="PlaceholderCompany">\nCopyright (c) PlaceholderCompany. All rights reserved.\n</copyright>
 
 # SA1636: File header copyright text should match
 # Justification: .editorconfig supports file headers, so specifying a stylecop.json file with the file header is not needed.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Version: 1.6.0 (Using https://semver.org/)
+# Version: 1.6.1 (Using https://semver.org/)
 # Updated: 2020-07-28
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
@@ -73,7 +73,7 @@ indent_style = tab
 
 # SA1636: File header copyright text should match
 # Justification: .editorconfig supports file headers, so specifying a stylecop.json file with the file header is not needed.
-# dotnet_diagnostic.SA1636.severity = none
+# dotnet_diagnostic.SA1636.severity = warning
 
 ##########################################
 # .NET Language Conventions

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Version: 1.6.1 (Using https://semver.org/)
-# Updated: 2020-09-21
+# Updated: 2020-10-01
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -69,11 +69,11 @@ indent_style = tab
 ##########################################
 
 # [*.{cs,csx,cake,vb,vbx}]
-# file_header_template = <copyright file="{fileName}" company="PlaceholderCompany">\nCopyright (c) PlaceholderCompany. All rights reserved.\n</copyright>
+# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
 
 # SA1636: File header copyright text should match
-# Justification: .editorconfig supports file headers, so specifying a stylecop.json file with the file header is not needed.
-# dotnet_diagnostic.SA1636.severity = warning
+# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
+# dotnet_diagnostic.SA1636.severity = none
 
 ##########################################
 # .NET Language Conventions

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Version: 1.6.1 (Using https://semver.org/)
-# Updated: 2020-07-28
+# Updated: 2020-09-21
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A very generic [.editorconfig](https://github.com/RehanSaeed/EditorConfig/blob/m
 ### .NET Code Style
 
 Extensive code style settings for C# and VB.NET have been defined that require the latest C# features to be used.
-All C# related code styles are consistent with [StyleCop's](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) default styles.
+All C# related code styles are consistent with [StyleCop's](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) default styles, with the exception of the file header definition, which has been changed to a more modern format.
 All .NET naming conventions are consistent with the .NET Framework Design Guideline's [Naming Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines).
 
 # What is .editorconfig?

--- a/Samples/CSharp/FieldsExamples.cs
+++ b/Samples/CSharp/FieldsExamples.cs
@@ -1,5 +1,5 @@
-// <copyright file="FieldsExamples.cs" company="PlaceholderCompany">
-// Copyright (c) PlaceholderCompany. All rights reserved.
+// <copyright file="FieldsExamples.cs" company="PROJECT-AUTHOR">
+// © PROJECT-AUTHOR
 // </copyright>
 
 namespace CSharpSamples

--- a/Samples/CSharp/FieldsExamples.cs
+++ b/Samples/CSharp/FieldsExamples.cs
@@ -1,5 +1,5 @@
-// <copyright file="FieldsExamples.cs" company="PROJECT-AUTHOR">
-// Copyright (©) PROJECT-AUTHOR. All Rights Reserved
+// <copyright file="FieldsExamples.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 
 namespace CSharpSamples


### PR DESCRIPTION
I've created this PR to update the default setting for checking the copyright header to `warning`, in order to bring it in line with [the StyleCop defaults](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/rulesets/StyleCopAnalyzersDefault.ruleset). The line is still commented out, but this change means the only modification required from the user is to uncomment the line -- they no longer need to uncomment and upgrade the severity.

I've also taken this opportunity to update the copyright message to [the StyleCop default](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md#copyright-headers). I believe this header is preferable as it uses a more standard format (based on having checked many GitHub projects), and it aligns with StyleCop, which I believe is the goal of this `.editorconfig` project.

I've furthermore:
- Removed `en-us` from the explanatory URL, to allow it to default to the user's settings as for the other URLs in the comments.
- Update the minor version.
- Updated the revision date.

I'm happy to revert any of the changes you disagree with. Just let me know.