### PR TITLE
Support PostCSS files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,7 +48,7 @@ indent_size = 2
 trim_trailing_whitespace = false
 
 # Web Files
-[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,pcss,svg,vue}]
 indent_size = 2
 
 # Batch Files

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A very generic [.editorconfig](https://github.com/RehanSaeed/EditorConfig/blob/m
 - YAML - .yml,  .yaml
 - HTML - .htm, .html
 - JavaScript - .js, .jsm, .ts, .tsx, .vue
-- CSS - .css, .sass, .scss, .less
+- CSS - .css, .sass, .scss, .less, .pcss
 - SVG - .svg
 - Markdown - .md
 - Visual Studio - .sln, .csproj, .vbproj, .vcxproj, .vcxproj.filters, .proj, .projitems, .shproj


### PR DESCRIPTION
`.pcss` extension is commonly used with [PostCSS](https://postcss.org/) files.

Supported by IDEs with following extensions: 
[PostCSS Language Support for VS Code](https://marketplace.visualstudio.com/items?itemName=csstools.postcss)
[PostCSS for Rider](https://plugins.jetbrains.com/plugin/8578-postcss)