### PR TITLE
dotnet_style_parentheses_in_other_operators = never_if_unnecessary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -97,7 +97,7 @@ dotnet_style_readonly_field = true:warning
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 # Expression-level preferences
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning


### PR DESCRIPTION
We got some better documentation from .NET about this setting which makes it clear that we should change our configuration from a `suggestion` of using `always_for_clarity` to a `warning` to use `never_if_unnecessary`:

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048#dotnet_style_parentheses_in_other_operators

```
// dotnet_style_parentheses_in_other_operators = always_for_clarity
var v = (a.b).Length;

// dotnet_style_parentheses_in_other_operators = never_if_unnecessary
var v = a.b.Length;
```

The second example seems more desirable. Not sure if I should class this as a breaking change as per Semver as it was only a suggestion before.