### PR TITLE
Visual Studio 16.10 Updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -123,6 +123,8 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # Undocumented
 dotnet_style_operator_placement_when_wrapping = end_of_line:warning
 csharp_style_prefer_null_check_over_type_check = true:warning
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules

--- a/.editorconfig
+++ b/.editorconfig
@@ -97,7 +97,7 @@ dotnet_style_readonly_field = true:warning
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 # Expression-level preferences
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
@@ -122,9 +122,6 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # dotnet_diagnostic.SA1636.severity = none
 # Undocumented
 dotnet_style_operator_placement_when_wrapping = end_of_line:warning
-csharp_style_prefer_null_check_over_type_check = true:warning
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_diagnostic.IDE0130.severity = suggestion
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 2.1.0 (Using https://semver.org/)
-# Updated: 2021-03-03
+# Version: 3.0.0 (Using https://semver.org/)
+# Updated: 2021-08-09
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.

--- a/.editorconfig
+++ b/.editorconfig
@@ -122,6 +122,7 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # dotnet_diagnostic.SA1636.severity = none
 # Undocumented
 dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules

--- a/.editorconfig
+++ b/.editorconfig
@@ -121,7 +121,10 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 # If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
 # dotnet_diagnostic.SA1636.severity = none
 # Undocumented
-dotnet_style_operator_placement_when_wrapping = end_of_line
+dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
 
 # C# Style Rules
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules


### PR DESCRIPTION
Fixes https://github.com/RehanSaeed/EditorConfig/issues/48.

# dotnet_style_parentheses_in_other_operators

We got some [better documentation](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048#dotnet_style_parentheses_in_other_operators) from .NET about this setting which makes it clear that we should change our configuration from a `suggestion` of using `always_for_clarity` to a `warning` to use `never_if_unnecessary`:

```cs
// dotnet_style_parentheses_in_other_operators = always_for_clarity
var v = (a.b).Length;

// dotnet_style_parentheses_in_other_operators = never_if_unnecessary
var v = a.b.Length;
```

The second example seems more desirable.

# dotnet_style_operator_placement_when_wrapping

Realized that this setting was missing the error level, so set it to `warning`.

# csharp_style_prefer_null_check_over_type_check

Enabled this setting to prefer `is not null` over `is object`. Set to warning level. See https://github.com/dotnet/roslyn/issues/55005.

```cs
// csharp_style_prefer_null_check_over_type_check = false
foo is object
// csharp_style_prefer_null_check_over_type_check = true
foo is not null
```

# dotnet_style_namespace_match_folder

Enabled this setting so that namespaces must match folders. Set at `suggestion` level as sometimes devs want to also use logical folders to group content instead of representing hard folders. This is particularly useful when a namespace contains a large amount of content. See https://github.com/dotnet/roslyn/pull/49990.

I've also polled the community for their thoughts on the defaults here https://twitter.com/RehanSaeedUK/status/1424724592082493440.