### PR TITLE
Add Markdown .mdx extension

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,7 +44,7 @@ indent_size = 2
 indent_size = 2
 
 # Markdown Files
-[*.md]
+[*.{md,mdx}]
 trim_trailing_whitespace = false
 
 # Web Files


### PR DESCRIPTION
This will handle `*.mdx` file extensions the same way as other regular Markdown files with `*.md`